### PR TITLE
Add additional numeric validation for lat/lon fields

### DIFF
--- a/gbfs-validator/schema/freeBikeStatus.json
+++ b/gbfs-validator/schema/freeBikeStatus.json
@@ -24,10 +24,14 @@
                 "type": "string"
               },
               "lat": {
-                "type": "number"
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
               },
               "lon": {
-                "type": "number"
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
               },
               "is_reserved": {
                 "type": ["boolean", "number"]

--- a/gbfs-validator/schema/stationInformation.json
+++ b/gbfs-validator/schema/stationInformation.json
@@ -30,10 +30,14 @@
                 "type": "string"
               },
               "lat": {
-                "type": "number"
+                "type": "number",
+                "minimum": -90,
+                "maximum": 90
               },
               "lon": {
-                "type": "number"
+                "type": "number",
+                "minimum": -180,
+                "maximum": 180
               },
               "address": {
                 "type": "string"


### PR DESCRIPTION
This PR adds additional numeric validation of lat/lon fields which can help find cases where lat/lon are mistakenly switched.